### PR TITLE
super is a reserved word, changed to _super

### DIFF
--- a/lib/modules/everymodule.js
+++ b/lib/modules/everymodule.js
@@ -33,13 +33,13 @@ var everyModule = module.exports = {
       if (this.hasOwnProperty('init'))
         delete this.init;
 
-      var super = this.init;
+      var _super = this.init;
       // since this.hasOwnProperty('init') is false
 
       this.init = function () {
-        this.super = super;
+        this._super = _super;
         fn.apply(this, arguments);
-        delete this.super;
+        delete this._super;
 
         // Do module compilation here, too
       };


### PR DESCRIPTION
Node.js now treats super as a reserved word according to ECMAScript spec. and will throw SyntaxError: <unknown message reserved_word> when used as an identifier.
