### PR TITLE
Fix oauth2 when utilized via an SSL connection.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,9 +24,7 @@ function cloneArray (arr) {
 
 exports.extractHostname = function (req) {
   var headers = req.headers
-    , protocol = req.connection.server.constructor.name === 'HTTPServer'
-               ? 'http://'
-               : 'https://'                          // === 'HTTPSServer'
+    , protocol = req.socket.pair ? 'https://' : 'http://'
     , host = headers.host;
   return protocol + host;
 };


### PR DESCRIPTION
req.connection.server.constructor is not defined (at least for me) with SSL enabled.  Req.socket.pair seems to only be defined when using SSL, but I only really tested this long enough to make it function.
