### PR TITLE
added an executeSequence method to modules

### DIFF
--- a/lib/modules/everymodule.js
+++ b/lib/modules/everymodule.js
@@ -49,7 +49,7 @@ var everyModule = module.exports = {
   , post: route('post')
   , stepseq: function (name, description) {
       this.configurable(name, description);
-      this._currSeq = 
+      this._currSeq =
         this._stepSequences[name] || (this._stepSequences[name] = new StepSequence(name, this));
       return this;
     }
@@ -92,8 +92,8 @@ var everyModule = module.exports = {
             this[k] = setTo;
             return this;
           };
-        this._configurable[property] = description || 
-                                       this.configurable[property] || 
+        this._configurable[property] = description ||
+                                       this.configurable[property] ||
                                        'No Description';
 
         // Add configurable to submodules that inherit from this
@@ -114,7 +114,7 @@ var everyModule = module.exports = {
 
       sequence.orderedStepNames.push(name);
 
-      this._currentStep = 
+      this._currentStep =
         steps[name] || (steps[name] = new Step(name, this));
 
       // For configuring what the actual business
@@ -124,7 +124,7 @@ var everyModule = module.exports = {
       // fb.fetchOAuthUser( function (...) {
       //   // Business logic goes here
       // } );
-      this.configurable(name, 
+      this.configurable(name,
         'STEP FN [' + name + '] function encapsulating the logic for the step `' + name + '`.');
       return this;
     }
@@ -176,11 +176,11 @@ var everyModule = module.exports = {
 
 
   , cloneOnSubmodule: ['cloneOnSubmodule', '_configurable']
-  
+
   , submodules: {}
 
     /**
-     * Creates a new submodule using prototypal 
+     * Creates a new submodule using prototypal
      * inheritance
      */
   , submodule: function (name) {
@@ -223,7 +223,7 @@ var everyModule = module.exports = {
     }
 
     /**
-     * Decorates the app with the routes required of the 
+     * Decorates the app with the routes required of the
      * module
      */
   , routeApp: function (app) {
@@ -269,6 +269,28 @@ var everyModule = module.exports = {
       seq.initialArgs = args;
       throw seq;
     }
+
+  , executeSequence: function (sequenceName) {
+      var seq = this._stepSequences[sequenceName]
+        , args = Array.prototype.slice.call(arguments, 1)
+        , p = this.Promise();
+
+      if (!seq) {
+        throw new Error('You are trying to execute a sequence named `' + sequenceName + '`, but there is no sequence with that name in the auth module, `' + this.name + '`.');
+      }
+
+      seq = seq.materialize();
+      var lastPromise = seq.start.apply(seq, args);
+
+      lastPromise.callback(function (lastStep) {
+        p.fulfill.apply(p, lastStep.promises.reduce( function (args, promise) {
+          args.push(seq.values[promise]);
+          return args;
+        }, []));
+      });
+
+      return p;
+  }
 
     // _steps maps step names to step objects
     // A step object is { accepts: [...], promises: [...] }
@@ -316,7 +338,7 @@ Object.defineProperty(everyModule, 'routes', {get: function () {
     for (var alias in _routes[method]) {
       method = method.toUpperCase();
       arr.push(method + ' (' + alias + ') [' +
-        self[alias]() + ']' + 
+        self[alias]() + ']' +
         _descriptions[alias].replace(routeDescPrefix[method], ''));
     }
   }
@@ -326,7 +348,7 @@ Object.defineProperty(everyModule, 'routes', {get: function () {
 everyModule
   .configurable({
       moduleTimeout: 'how long to wait per step ' +
-        'before timing out and invoking any ' + 
+        'before timing out and invoking any ' +
         'timeout callbacks'
     , moduleErrback: 'THE error callback that is invoked' +
         'any time an error occurs in the module; defaults to `throw` wrapper'

--- a/lib/stepSequence.js
+++ b/lib/stepSequence.js
@@ -19,7 +19,7 @@ var materializedMethods = {
         var resultPromise = nextStep.exec(seq);
         if (!resultPromise) return; // if we have a breakTo
         resultPromise.callback( function () {
-          nextPromise.fulfill();
+          nextPromise.fulfill(nextStep);
         }); // TODO breakback?
       });
       return nextPromise;
@@ -57,7 +57,7 @@ var materializedMethods = {
       var firstStep = this.steps[0]
         , seq = this;
       firstStep.accepts.forEach( function (paramName, i) {
-        // Map the incoming arguments to the named parameters 
+        // Map the incoming arguments to the named parameters
         // that the first step is expected to accept.
         seq.values[paramName] = args[i];
       });
@@ -101,7 +101,7 @@ StepSequence.prototype = {
           throw new Error('You did not declare promises for the step: ' + step.name);
         }
 
-        if (i === 0) 
+        if (i === 0)
           paramsToDate = paramsToDate.concat(step.accepts);
 
         missingParams = step.accepts.filter( function (param) {
@@ -110,7 +110,7 @@ StepSequence.prototype = {
 
         if (i > 0 && missingParams.length)
           throw new Error('At step, ' + step.name + ', you are trying to access the parameters: ' + missingParams.join(', ') + ' . However, only the following parameters have been promised from prior steps thus far: ' + paramsToDate.join(', '));
-        
+
         paramsToDate = paramsToDate.concat(step.promises);
 
         if ('undefined' === typeof this.module[step.name]())
@@ -164,12 +164,12 @@ Object.defineProperty(StepSequence.prototype, 'steps', {
           meta.missing.push('its function');
 
         return meta;
-        
+
       });
 
       return ret;
     }
-    
+
     var compiledSteps;
 
     Object.defineProperty(orderedSteps, 'incomplete', { get: function () {
@@ -188,10 +188,10 @@ Object.defineProperty(StepSequence.prototype, 'steps', {
       return compiledSteps.filter( function (stepMeta) {
         return stepMeta.missingParams.length > 0;
       }).map( function (stepMeta) {
-        var error = 'is trying to accept the parameters: ' + 
-                  stepMeta.missingParams.join(', ') + 
-                  ' . However, only the following parameters have ' + 
-                  'been promised from prior steps thus far: ' + 
+        var error = 'is trying to accept the parameters: ' +
+                  stepMeta.missingParams.join(', ') +
+                  ' . However, only the following parameters have ' +
+                  'been promised from prior steps thus far: ' +
                   stepMeta.paramsToDate.join(', ');
         return { name: stepMeta.step.name, error: error };
       });


### PR DESCRIPTION
Hey there!

First off, thanks a ton for your work on everyauth, it's been really awesome to work with!

So I've made a little change, and I'd love if you could give me feedback on improving it, and hopefully be able to merge it into master, because I'd love to make use of it.

Basically, I want to make it possible to create stepSequences that are intended for external consumption, but not triggered by routes.  As an example, I might have (from some aribtrary means such as user input) a facebook accessToken and I'd like to fetch the associated user with it.  So I'd build a little sequence like so:

```
everyauth.facebook
  .stepseq('fetchUserWithAccessToken')
    .step('fetchOAuthUser')
      .accepts('accessToken')
      .promises('oauthUser')
    .step('findOrCreateUser')
      .accepts('accessToken oauthUser')
      .promises('user')
```

This leverages all of the existing everyauth infrastructure (and you'll notice it's an abbreviated version of the oauth2 module's callbackPath sequence).

From application code, I'd execute it like so:

```
everyauth.facebook.executeSequence('fetchUserWithAccessToken', 'some-access-token').callback(function(user) {
   // use the user for something
});
```

So it basically allows you to create custom chains of methods and decompose everyauth even more, which enhances the flexibility of the library quite a bit.  For instance, I could now write custom middleware that parses an incoming request in an arbitrary way, delegates out to everyauth to authenticate the user, and then calls back in and continues the request, instead of having the build the whole thing directly into everyauth as a route-triggered-sequence.

Let me know if this sounds useful, and if there's anything I can do to get this merged!
