### PR TITLE
Use x-forwarded-proto to detect https for servers behind an https proxy

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,7 +26,7 @@ function cloneArray (arr) {
 
 exports.extractHostname = function (req) {
   var headers = req.headers
-    , protocol = req.connection.server instanceof tls.Server
+    , protocol = (req.connection.server instanceof tls.Server || req.headers['x-forwarded-proto'] == 'https')
                ? 'https://'
                : 'http://'
     , host = headers.host;


### PR DESCRIPTION
This allows the extractHostname() detection of HTTPS to work properly for servers that are having HTTPS proxied in front of them.
