### PR TITLE
Fixes infinite loop in phone sanitization

### DIFF
--- a/lib/modules/password.js
+++ b/lib/modules/password.js
@@ -354,13 +354,8 @@ password.validLoginTypes({
     }
   , phone: {
         sanitize: function (value) {
-          // Pull out only digits and 'x' for extension
-          var digitOrX = /[\dx]/i
-            , match, ret = '';
-          while (match = digitOrX.exec(value)) {
-            ret += match[0];
-          }
-          return ret;
+          // Pull out only +, digits and 'x' for extension
+          return value.replace(/[^\+\dx]/g, '');
         }
       , validate: function (value) {
           return value.length >= 7;


### PR DESCRIPTION
Hi Brian

.loginWith('phone') causes an infinite loop with a value of e.g. '123' due to broken sanitize function. Suggest using .replace instead of the while loop.

Thanks for the useful library!

Cheers
Isaac
