### PR TITLE
Ensure session exists before accessing its members.

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ everyauth
 
   }).addRequestGetter('loggedIn', function () {
     var req = this;
-    if (req.session.auth && req.session.auth.loggedIn) {
+    if (req.session && req.session.auth && req.session.auth.loggedIn) {
       return true;
     } else {
       return false;


### PR DESCRIPTION
Fixes an issue I'm having with loggedIn failing when no session exists.  This diff works for me and is just one more sanity check to the req.session.auth.loggedIn access, so pretty safe.
