### PR TITLE
Added possibility to pass parameters to the authorize path.

### DIFF
--- a/lib/modules/oauth.js
+++ b/lib/modules/oauth.js
@@ -11,6 +11,7 @@ everyModule.submodule('oauth')
     , requestTokenPath: "the path on the OAuth provider's domain where we request the request token, e.g., /oauth/request_token"
     , accessTokenPath: "the path on the OAuth provider's domain where we request the access token, e.g., /oauth/access_token"
     , authorizePath: 'the path on the OAuth provider where you direct a visitor to login, e.g., /oauth/authorize'
+    , authorizeParams: 'the params which will be appended to the authorizePath (e.g. force_login).'
     , sendCallbackWithAuthorize: 'whether you want oauth_callback=... as a query param send with your request to /oauth/authorize'
     , consumerKey: 'the api key provided by the OAuth provider'
     , consumerSecret: 'the api secret provided by the OAuth provider'
@@ -120,7 +121,18 @@ everyModule.submodule('oauth')
     // module needs it as a uri query parameter. However, in cases such as twitter, it allows you to over-ride
     // the callback url settings at dev.twitter.com from one place, your app code, rather than in two places -- i.e.,
     // your app code + dev.twitter.com app settings.
-    var redirectTo = this._oauthHost + this._authorizePath + '?oauth_token=' + token;
+    var params = this._authorizeParams;
+    var querystring = '?';
+
+    if (params) {
+      for(var key in params) {
+        if(params.hasOwnProperty(key)) {
+          querystring += key + '=' + params[key] + '&';
+        }
+      }
+    }
+
+    var redirectTo = this._oauthHost + this._authorizePath + querystring + 'oauth_token=' + token;
     if (this._sendCallbackWithAuthorize) {
       redirectTo += '&oauth_callback=' + this._myHostname + this._callbackPath;
     }

--- a/lib/modules/oauth.js
+++ b/lib/modules/oauth.js
@@ -126,10 +126,8 @@ everyModule.submodule('oauth')
     var query = '?';
 
     if (params) {
-      query += querystring.stringify(params);
+      query += querystring.stringify(params) + '&';
     }
-
-    query += '&';
 
     var redirectTo = this._oauthHost + this._authorizePath + query + 'oauth_token=' + token;
     if (this._sendCallbackWithAuthorize) {

--- a/lib/modules/oauth.js
+++ b/lib/modules/oauth.js
@@ -1,7 +1,8 @@
 var everyModule = require('./everymodule')
   , OAuth = require('oauth').OAuth
   , url = require('url')
-  , extractHostname = require('../utils').extractHostname;
+  , extractHostname = require('../utils').extractHostname
+  , querystring = require('querystring');
 
 var oauth = module.exports =
 everyModule.submodule('oauth')
@@ -122,17 +123,15 @@ everyModule.submodule('oauth')
     // the callback url settings at dev.twitter.com from one place, your app code, rather than in two places -- i.e.,
     // your app code + dev.twitter.com app settings.
     var params = this._authorizeParams;
-    var querystring = '?';
+    var query = '?';
 
     if (params) {
-      for(var key in params) {
-        if(params.hasOwnProperty(key)) {
-          querystring += key + '=' + params[key] + '&';
-        }
-      }
+      query += querystring.stringify(params);
     }
 
-    var redirectTo = this._oauthHost + this._authorizePath + querystring + 'oauth_token=' + token;
+    query += '&';
+
+    var redirectTo = this._oauthHost + this._authorizePath + query + 'oauth_token=' + token;
     if (this._sendCallbackWithAuthorize) {
       redirectTo += '&oauth_callback=' + this._myHostname + this._callbackPath;
     }


### PR DESCRIPTION
In my current project I need the opportunity to realise a "real twitter logout" which means that it is not enough to erase the session. The user has to login via twitter again if he would like to access the application.

I have seen that there is a "force_login=true" parameter for the "/oauth/authenticate" action in the Twitter API that forces the user to enter their credentials. Unfortunately, I did not find the possibility to add the params to the url, so that I've implemented a "authorizeParams" function in which you can put the params that will be appended to the authenticate url:

``` javascript
            everyauth
                .twitter
                .authorizeParams({force_login: true})
```

So in my case: If the user tries to login via: '/auth/twitter' he will be redirected to the twitter login page.

I hope that this is useful for someone.
