### PR TITLE
Avoid clobbering properties on the compiled object from the extra object

### DIFF
--- a/lib/modules/oauth2.js
+++ b/lib/modules/oauth2.js
@@ -181,7 +181,11 @@ everyModule.submodule('oauth2')
     // oauth provider in response to the access token
     // POST request
     for (var k in extra) {
-      compiled[k] = extra[k];
+      // avoid clobbering any of the properties we set just above (user, accessToken, oauthUser)
+      // instagram in particular sends a "user" which can break your code in strange ways if it's overwritten
+      if (extra.hasOwnProperty(k) && !compiled.hasOwnProperty(k)) {
+        compiled[k] = extra[k];
+      }
     }
     return compiled;
   })


### PR DESCRIPTION
I noticed a bug with Instagram where the "extra" object had a property that was "user", which in the case of this compile function would clobber the value we set there and give invalid user object back to the application.  I just added a very simple check that we won't do that (and I also added the other hasOwnPropertyCheck while I was at it). Thanks!
