### PR TITLE
Alter OAuth2 so that you can specify the redirectPath in the url

### DIFF
--- a/lib/modules/oauth2.js
+++ b/lib/modules/oauth2.js
@@ -170,7 +170,7 @@ everyModule.submodule('oauth2')
       opts.headers || (opts.headers = {});
       opts.headers['Content-Length'] = 0;
     }
-    delete opts.query.redirect_uri
+    // delete opts.query.redirect_uri
     rest[this.accessTokenHttpMethod()](url, opts)
       .on('success', function (data, res) {
         if ('string' === typeof data) {


### PR DESCRIPTION
I need to be able to redirect to different parts of my app after authorisation and wanted to be able to specify the redirectPath in the href of the link to the everyauth handler. 

for example: 
I have the redirectPath set to be /#/dashboard in my app but if I wanted to go somewhere else after logging in with facebook i can link to http://myapp.com/auth/facebook?redirect_path=/#/sendmessage and this will redirect me to /#/sendmessage after logging in. 

This will need to be incorporated into the other methods of authentication but at least it is a start. 
