### PR TITLE
Set local scope on ret variable

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -35,6 +35,7 @@ Step.prototype = {
       // access to all data promised by prior steps via the last argument -- `seq.values`
       args.push(seq.values);
 
+      var ret;
       try {
         // Apply the step logic
 


### PR DESCRIPTION
The variable ret is leaking into global scope.  This adds a 'var' declaration to prevent this.
