### PR TITLE
Update lib/modules/linkedin.js

### DIFF
--- a/lib/modules/linkedin.js
+++ b/lib/modules/linkedin.js
@@ -22,7 +22,7 @@ oauthModule.submodule('linkedin')
   .oauthHost('https://api.linkedin.com')
 
   .requestTokenPath('/uas/oauth/requestToken')
-  .authorizePath('/uas/oauth/authorize')
+  .authorizePath('/uas/oauth/authenticate')
   .accessTokenPath('/uas/oauth/accessToken')
 
   .entryPath('/auth/linkedin')


### PR DESCRIPTION
Changed from `/authorize` to `/authenticate`. The former requires a user to re-allow the LinkedIn app _every_ time, while the latter does not.
