### PR TITLE
OpenID fix.

### DIFF
--- a/lib/modules/openid.js
+++ b/lib/modules/openid.js
@@ -51,7 +51,7 @@ everyModule.submodule('openid')
       this.myHostname(extractHostname(req));
     }
 
-    this.relyingParty.authenticate(req.query[this.openidURLField()], false, function(err,authenticationUrl){
+    this.relyingParty.authenticate(this.openidURLField(), false, function(err,authenticationUrl){
       if(err) return p.fail(err);
       res.writeHead(302, { Location: authenticationUrl });
       res.end();


### PR DESCRIPTION
I don't know why "req.query[]" was there, but that was the reason why the OpenID part of Everyauth wasn't working for me. I hope it'll help.
