### PR TITLE
support external redirect mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,8 +268,7 @@ everyauth.everymodule.handleLogout( function (req, res) {
   
   // And/or put your extra logic here
   
-  res.writeHead(303, { 'Location': this.logoutRedirectPath() });
-  res.end();
+  this.redirect(res, this.logoutRedirectPath());
 });
 ```
 
@@ -277,19 +276,30 @@ everyauth.everymodule.handleLogout( function (req, res) {
 
 You may want your own callback that decides where to send a user after login or registration.  One way of doing this is with the `respondToLoginSucceed` and `respondToRegistrationSucceed` methods.  This assumes that you have set a `.redirectTo` property on your `req.session` object:
 
-```
+```javascript
 everyauth.password
   .respondToLoginSucceed( function (res, user, data) {
     if (user) {
-      res.writeHead(303, {'Location': data.session.redirectTo});
-      res.end();
+      this.redirect(res, data.session.redirectTo)
     }   
   })
   .respondToRegistrationSucceed( function (res, user, data) {
-    res.writeHead(303, {'Location': data.session.redirectTo});
-    res.end();
+    this.redirect(res, data.session.redirectTo)
   })
 ```
+
+If you are using express and want your redirects to be subject to [express
+redirect mapping](http://expressjs.com/guide.html#res.redirect\(\)), you can
+overwrite redirect method employed by everyauth.
+
+```javascript
+everyauth.everymodule
+  .performRedirect( function (res, location) {
+    res.redirect(location, 303);
+  });
+```
+
+A newly defined method will be used by everyauth to perform all redirects.
 
 # Auth Strategy Instructions
 

--- a/lib/modules/azureacs.js
+++ b/lib/modules/azureacs.js
@@ -80,9 +80,7 @@ everyModule.submodule('azureacs')
 
   .redirectToIdentityProviderSelector( function (req, res) {
     var identityProviderSelectorUri = this.wsfederation.getRequestSecurityTokenUrl();
-    
-    res.writeHead(303, {'Location': identityProviderSelectorUri});
-    res.end();
+    this.redirect(res, identityProviderSelectorUri);
   })
 
   .getToken( function (req, res) {
@@ -131,15 +129,14 @@ everyModule.submodule('azureacs')
     _auth.loggedIn = true;
     _auth.userId || (_auth.userId = acsUser.id);
     mod.user = acsUser;
-    mod.accessToken = token; 
+    mod.accessToken = token;
   })
 
   .sendResponse( function (res) {
     var redirectTo = this.redirectPath();
     if (!redirectTo)
       throw new Error('You must configure a redirectPath');
-    res.writeHead(303, {'Location': redirectTo});
-    res.end();
+    this.redirect(res, redirectTo);
   })
 
   .authCallbackDidErr( function (req) {

--- a/lib/modules/box.js
+++ b/lib/modules/box.js
@@ -70,10 +70,7 @@ everyModule.submodule('box')
     return promise;
   })
   .redirectToBoxAuth( function (res, ticket) {
-    res.writeHead(303, {
-      'Location': this._apiHost + '/auth/' + ticket
-    });
-    res.end();
+    this.redirect(res, this._apiHost + '/auth/' + ticket);
   })
 
   .extractAuthToken( function (req, res) {
@@ -121,8 +118,7 @@ everyModule.submodule('box')
     var redirectTo = this.redirectPath();
     if (!redirectTo)
       throw new Error('You must configure a redirectPath');
-    res.writeHead(303, {'Location': redirectTo});
-    res.end();
+    this.redirect(res, redirectTo);
   })
   
   .entryPath('/auth/box')

--- a/lib/modules/everymodule.js
+++ b/lib/modules/everymodule.js
@@ -47,6 +47,9 @@ var everyModule = module.exports = {
     }
   , get: route('get')
   , post: route('post')
+  , redirect: function (req, location) {
+    this._performRedirect(req, location);
+  }
   , stepseq: function (name, description) {
       this.configurable(name, description);
       this._currSeq = 
@@ -334,6 +337,7 @@ everyModule
         'any time an error occurs in the module; defaults to `throw` wrapper'
     , logoutRedirectPath: 'where to redirect the app upon logging out'
     , findUserById: 'function for fetching a user by his/her id -- used to assign to `req.user` - function (userId, callback) where function callback (err, user)'
+    , performRedirect: 'function for redirecting responses'
   })
   .get('logoutPath')
     .step('handleLogout')
@@ -342,10 +346,14 @@ everyModule
   .logoutPath('/logout')
   .handleLogout( function (req, res) {
     req.logout();
-    res.writeHead(303, { 'Location': this.logoutRedirectPath() });
-    res.end();
+    this.redirect(res, this.logoutRedirectPath());
   })
   .logoutRedirectPath('/');
+
+everyModule.performRedirect( function(res, location) {
+  res.writeHead(303, { 'Location': location });
+  res.end();
+});
 
 everyModule.moduleTimeout(10000);
 everyModule.moduleErrback( function (err) {

--- a/lib/modules/googlehybrid.js
+++ b/lib/modules/googlehybrid.js
@@ -54,8 +54,7 @@ openidModule.submodule('googlehybrid')
 
     this.relyingParty.authenticate('http://www.google.com/accounts/o8/id', false, function (err,authenticationUrl){
       if(err) return p.fail(err);
-      res.writeHead(302, { Location: authenticationUrl });
-      res.end();
+      this.redirect(res, authenticationUrl);
     });
   }) 
   .entryPath('/auth/googlehybrid')

--- a/lib/modules/linkedin.js
+++ b/lib/modules/linkedin.js
@@ -29,8 +29,7 @@ oauthModule.submodule('linkedin')
   .callbackPath('/auth/linkedin/callback')
 
   .redirectToProviderAuth( function (res, token) {
-    res.writeHead(303, { 'Location': 'https://www.linkedin.com' + this.authorizePath() + '?oauth_token=' + token });
-    res.end();
+    this.redirect(res, 'https://www.linkedin.com' + this.authorizePath() + '?oauth_token=' + token);
   })
 
   .fetchOAuthUser( function (accessToken, accessTokenSecret, params) {

--- a/lib/modules/oauth.js
+++ b/lib/modules/oauth.js
@@ -125,8 +125,7 @@ everyModule.submodule('oauth')
     if (this._sendCallbackWithAuthorize) {
       redirectTo += '&oauth_callback=' + this._myHostname + this._callbackPath;
     }
-    res.writeHead(303, { 'Location': redirectTo });
-    res.end();
+    this.redirect(res, redirectTo);
   })
 
   // Steps for GET `callbackPath`
@@ -200,8 +199,7 @@ everyModule.submodule('oauth')
     var redirectTo = this.redirectPath();
     if (!redirectTo)
       throw new Error('You must configure a redirectPath');
-    res.writeHead(303, {'Location': redirectTo});
-    res.end();
+    this.redirect(res, redirectTo);
   })
 
   .waitForPriorRequestToWriteSession( function (req, res) {

--- a/lib/modules/oauth2.js
+++ b/lib/modules/oauth2.js
@@ -124,8 +124,7 @@ everyModule.submodule('oauth2')
     return url + '?' + querystring.stringify(params);
   })
   .requestAuthUri( function (res, authUri) {
-    res.writeHead(303, {'Location': authUri});
-    res.end();
+    this.redirect(res, authUri);
   })
   .getCode( function (req, res) {
     var parsedUrl = url.parse(req.url, true);
@@ -222,8 +221,7 @@ everyModule.submodule('oauth2')
     var redirectTo = this.redirectPath();
     if (!redirectTo)
       throw new Error('You must configure a redirectPath');
-    res.writeHead(303, {'Location': redirectTo});
-    res.end();
+    this.redirect(res, redirectTo);
   })
   
   .authCallbackDidErr( function (req, res) {

--- a/lib/modules/openid.js
+++ b/lib/modules/openid.js
@@ -53,8 +53,7 @@ everyModule.submodule('openid')
 
     this.relyingParty.authenticate(req.query[this.openidURLField()], false, function(err,authenticationUrl){
       if(err) return p.fail(err);
-      res.writeHead(302, { Location: authenticationUrl });
-      res.end();
+      this.redirect(res, authenticationUrl);
     });
   })
   .getSession( function(req) {
@@ -79,8 +78,7 @@ everyModule.submodule('openid')
     var redirectTo = this.redirectPath();
     if (!redirectTo)
       throw new Error('You must configure a redirectPath');
-    res.writeHead(303, {'Location': redirectTo});
-    res.end();
+    this.redirect(res, redirectTo);
   })
   .redirectPath('/')
   .entryPath('/auth/openid')

--- a/lib/modules/password.js
+++ b/lib/modules/password.js
@@ -205,8 +205,7 @@ everyModule.submodule('password')
   })
   .respondToLoginSucceed( function (res, user) {
     if (user) {
-      res.writeHead(303, {'Location': this.loginSuccessRedirect()});
-      res.end();
+      this.redirect(res, this.loginSuccessRedirect());
     }
   })
   .respondToLoginFail( function (req, res, errors, login) {
@@ -327,8 +326,7 @@ everyModule.submodule('password')
     return user;
   })
   .respondToRegistrationSucceed( function (res, user) {
-    res.writeHead(303, {'Location': this.registerSuccessRedirect()});
-    res.end();
+    this.redirect(res, this.registerSuccessRedirect());
   })
 
   .stepseq('registrationFailSteps')

--- a/lib/modules/tripit.js
+++ b/lib/modules/tripit.js
@@ -12,8 +12,7 @@ oauthModule.submodule('tripit')
     if (this.sendCallbackWithAuthorize()) {
       redirectTo += '&oauth_callback=' + this.myHostname() + this.callbackPath();
     }
-    res.writeHead(303, { 'Location': redirectTo });
-    res.end();
+    this.redirect(res, redirectTo);
   })
   .fetchOAuthUser( function (accessToken, accessTokenSecret, params) {
     var promise = this.Promise();


### PR DESCRIPTION
express has rather elegant methods for [redirect mapping](http://expressjs.com/guide.html#res.redirect%28%29). 
It is possible to use it with current everyauth implementation, but you need to overwrite several methods performing redirects, which might be different for each module.

This commit changes all redirects to `this.redirect`, which is not strictly necessary. It internally calls 
`everymodule.performRedirect` which might be conveniently overwritten.

Default implementation of `performRedirect`:

``` javascript
res.writeHead(303, { 'Location': location });
res.end();
```

Defining a single redirect function that all modules use allows for centralized redirect mapping. Specifically express users may want to deploy res.redirect to implement successful login redirection.
