### PR TITLE
[fix] Use https tarball url instead of git+ssh

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lib": "lib"
   },
   "dependencies": {
-    "oauth": "git+ssh://git@github.com:ciaranj/node-oauth.git",
+    "oauth": "https://github.com/ciaranj/node-oauth/tarball/master",
     "restler": ">=0.2.1",
     "request": ">=2.2.0",
     "connect": ">=1 <2",


### PR DESCRIPTION
If the git ssh syntax is used, then a github account's private key needs to be available on the machine in order to clone the repository.  With the https:// url, public repositories may be cloned without ssh private keys being present.
