### PR TITLE
Scopes not parsed correctly for Google Hybrid

### DIFF
--- a/lib/modules/googlehybrid.js
+++ b/lib/modules/googlehybrid.js
@@ -20,7 +20,7 @@ openidModule.submodule('googlehybrid')
           })
         , new oid.OAuthHybrid({
               consumerKey: this._consumerKey
-            , scope: this._scope.join('+')
+            , scope: this._scope.join(' ')
           })
       ]);
 
@@ -51,10 +51,12 @@ openidModule.submodule('googlehybrid')
     if (!this._myHostname || this._alwaysDetectHostname) {
       this.myHostname(extractHostname(req));
     }
-
+    
+    var self = this;
+    
     this.relyingParty.authenticate('http://www.google.com/accounts/o8/id', false, function (err,authenticationUrl){
       if(err) return p.fail(err);
-      this.redirect(res, authenticationUrl);
+      self.redirect(res, authenticationUrl);
     });
   }) 
   .entryPath('/auth/googlehybrid')


### PR DESCRIPTION
Scopes need to be joined with spaces ' ' and not +.

Another change:
this.redirect on line 59 -- "this" does not refer to the proper entity in the scope of the callback function. Passed it as a free variable "self" from the upper scope.
