### PR TITLE
Add fields option to facebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,8 @@ the same chainable API:
 everyauth.facebook
   .entryPath('/auth/facebook')
   .callbackPath('/auth/facebook/callback')
-  .scope('email')                // Defaults to undefined
+  .scope('email')                        // Defaults to undefined
+  .fields('id,name,email,picture')       // Controls the returned fields. Defaults to undefined
 ```
 
 If you want to see what the current value of a
@@ -366,6 +367,7 @@ configured parameter is, you can do so via:
 
 ```javascript
 everyauth.facebook.scope(); // undefined
+everyauth.facebook.fields(); // undefined
 everyauth.facebook.entryPath(); // '/auth/facebook'
 ```
 

--- a/lib/modules/facebook.js
+++ b/lib/modules/facebook.js
@@ -4,7 +4,8 @@ var oauthModule = require('./oauth2')
 var fb = module.exports =
 oauthModule.submodule('facebook')
   .configurable({
-      scope: 'specify types of access: See http://developers.facebook.com/docs/authentication/permissions/'
+      scope: 'specify types of access: See http://developers.facebook.com/docs/authentication/permissions/',
+      fields: 'specify returned fields: See http:/developers.facebook.com/docs/reference/api/user/'
   })
 
   .apiHost('https://graph.facebook.com')
@@ -38,7 +39,11 @@ oauthModule.submodule('facebook')
 
   .fetchOAuthUser( function (accessToken) {
     var p = this.Promise();
-    this.oauth.get(this.apiHost() + '/me', accessToken, function (err, data) {
+    var fieldsQuery = "";
+    if (this.fields() && this.fields().length > 0){
+        fieldsQuery = "?fields=" + this.fields();
+    }
+    this.oauth.get(this.apiHost() + '/me' + fieldsQuery, accessToken, function (err, data) {
       if (err)
         return p.fail(err);
       var oauthUser = JSON.parse(data);


### PR DESCRIPTION
See http://developers.facebook.com/docs/reference/api/user

Adding a configurable variable to the facebook.js module to control the returned fields for a user object.
This might be useful when we want fields that are not returned by default like 'picture'.
