### PR TITLE
Provide 'req' to  findUserById function (if needed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,17 @@ everyauth.everymodule.findUserById( function (userId, callback) {
 });
 ```
 
+If you need access to the request object the function can have three arguments:
+
+```javascript
+everyauth.everymodule.findUserById( function (req, userId, callback) {
+
+  // use the request in some way ...
+
+  // callback has the signature, function (err, user) {...}
+});
+```
+
 Once you have configured this method, you now have access to the user object
 that was fetched anywhere in your server app code as `req.user`. For instance:
 

--- a/index.js
+++ b/index.js
@@ -80,7 +80,8 @@ everyauth.middleware = function () {
         if (!auth || !auth.userId) return next();
         var everymodule = everyauth.everymodule;
         var pause = __pause(req);
-        everymodule.findUserById()(auth.userId, function (err, user) {
+
+        var findUserById_callback = function (err, user) {
           if (err) {
             pause.resume();
             return next(err);
@@ -89,7 +90,14 @@ everyauth.middleware = function () {
           else delete sess.auth;
           next();
           pause.resume();
-        });
+        }; 
+
+        var findUserById_function = everymodule.findUserById();
+        
+        findUserById_function.length === 3
+          ? findUserById_function( req, auth.userId, findUserById_callback )
+          : findUserById_function(      auth.userId, findUserById_callback );
+
       }
     , connect.router(function (app) {
         var modules = everyauth.enabled

--- a/lib/modules/everymodule.js
+++ b/lib/modules/everymodule.js
@@ -319,7 +319,7 @@ everyModule
     , moduleErrback: 'THE error callback that is invoked any time an error occurs in the module; ' +
         'defaults to `throw` wrapper'
     , logoutRedirectPath: 'Where to redirect the app upon logging out'
-    , findUserById: 'function for fetching a user by his/her id -- used to assign to `req.user` - function (userId, callback) where function callback (err, user)'
+    , findUserById: 'function for fetching a user by his/her id -- used to assign to `req.user` - function ( [req], userId, callback) where function callback (err, user)'
     , performRedirect: 'function for redirecting responses'
     , userPkey: 'identifying property of the user; defaults to "id"'
   })


### PR DESCRIPTION
I'm working on an app that uses a different database depending on the domain name used to access it - a multi-tenant app if you will.

To use everyauth I need to be able to choose the database to look up the user in based on the domain name, and so need access to the request.

The attached change allows for a three argument form of `findUserById` which is handles this. The existing two argument form is also supported so this change is backwards compatible.
