### PR TITLE
Fix https detection for Express 3

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,7 +26,7 @@ function cloneArray (arr) {
 
 exports.extractHostname = function (req) {
   var headers = req.headers
-    , protocol = (req.connection.server instanceof tls.Server || req.headers['x-forwarded-proto'] == 'https')
+    , protocol = (req.connection.server instanceof tls.Server || req.socket.socket.server instanceof tls.Server || req.headers['x-forwarded-proto'] == 'https')
                ? 'https://'
                : 'http://'
     , host = headers.host;


### PR DESCRIPTION
`req.connection.server` is no longer used in Express 3. Use `req.socket.socket.server` instead.
