### PR TITLE
fix for openid module, i guess it wasn't updated to latest express version yet

### DIFF
--- a/lib/modules/openid.js
+++ b/lib/modules/openid.js
@@ -53,7 +53,7 @@ everyModule.submodule('openid')
 
     this.relyingParty.authenticate(req.query[this.openidURLField()], false, function(err,authenticationUrl){
       if(err) return p.fail(err);
-      this.redirect(res, authenticationUrl);
+      res.redirect(authenticationUrl);
     });
   })
   .getSession( function(req) {
@@ -78,7 +78,7 @@ everyModule.submodule('openid')
     var redirectTo = this.redirectPath();
     if (!redirectTo)
       throw new Error('You must configure a redirectPath');
-    this.redirect(res, redirectTo);
+    res.redirect(redirectTo);
   })
   .redirectPath('/')
   .entryPath('/auth/openid')


### PR DESCRIPTION
Without this fix i get the following error:

TypeError: Object #<Object> has no method 'redirect'
    at C:\Develop\medienverwaltung\Medienverwaltung\backend\node_modules\everyauth\lib\modules\openid.js:57:12

```
"dependencies": {
    "express": "2.5.8",
    "everyauth": "0.2.32",
    "mongoose": "2.6.0"
}
```

actually my first pull request ever :-)
