### PR TITLE
Local password authentication.

### DIFF
--- a/lib/modules/password.js
+++ b/lib/modules/password.js
@@ -199,11 +199,14 @@ everyModule.submodule('password')
   })
   .addToSession( function (sess, user, errors) {
     var _auth = sess.auth || (sess.auth = {});
-    if (user)
-      _auth.userId = user[this._userPkey];
+    if (user) {
+      for(key in user) {
+        if(key!='salt' && key!='hash')
+          _auth[key] = user[key];
+      }
+    }
     _auth.loggedIn = !!user;
-  })
-  .respondToLoginSucceed( function (res, user) {
+  })  .respondToLoginSucceed( function (res, user) {
     if (user) {
       this.redirect(res, this.loginSuccessRedirect());
     }


### PR DESCRIPTION
Hello, my first open source commit (attempt!).
I've been using everyauth for a few weeks now and it's been quite useful!
While using the password authentication scheme, I still wanted to be able to pull information about the user.  However, none of the information that was automatically retrieved from the other authentication schemes (ex, I tested with Twitter) was accessible.
Upon reading the source I found that the sessions .userId was being hard set to an expected user.id (or apparently in a later push, a configurable primary key).
Here was my solution to the problem anyway- if the user is available, we should push all the fields we have into the session.  (In my case, I chose to exclude the 'salt' and 'hash' fields for my users passwords, this should probably be set up to be an configurable exclusions list).
