### PR TITLE
Add return_ssl_resources option to facebook module

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ everyauth.facebook
   .callbackPath('/auth/facebook/callback')
   .scope('email')                        // Defaults to undefined
   .fields('id,name,email,picture')       // Controls the returned fields. Defaults to undefined
+  .returnSSLResources(true)              // Return url resources with https prefix. Defaults to undefined (false)
 ```
 
 If you want to see what the current value of a
@@ -385,6 +386,7 @@ configured parameter is, you can do so via:
 ```javascript
 everyauth.facebook.scope(); // undefined
 everyauth.facebook.fields(); // undefined
+everyauth.facebook.returnSSLResources(); // undefined
 everyauth.facebook.entryPath(); // '/auth/facebook'
 ```
 

--- a/lib/modules/facebook.js
+++ b/lib/modules/facebook.js
@@ -5,7 +5,8 @@ var fb = module.exports =
 oauthModule.submodule('facebook')
   .configurable({
       scope: 'specify types of access: See http://developers.facebook.com/docs/authentication/permissions/',
-      fields: 'specify returned fields: See http:/developers.facebook.com/docs/reference/api/user/'
+      fields: 'specify returned fields: See http:/developers.facebook.com/docs/reference/api/user/',
+      returnSSLResources: 'indicates whether to return url resources with https prefix (to avoid mixed content warning in https sites)'
   })
 
   .apiHost('https://graph.facebook.com')
@@ -39,11 +40,14 @@ oauthModule.submodule('facebook')
 
   .fetchOAuthUser( function (accessToken) {
     var p = this.Promise();
-    var fieldsQuery = "";
-    if (this._fields && this._fields.length > 0){
-        fieldsQuery = "?fields=" + this.fields();
+    var query = {};
+    if (this.fields() && this.fields().length > 0){
+      query.fields = this.fields();
     }
-    this.oauth.get(this.apiHost() + '/me' + fieldsQuery, accessToken, function (err, data) {
+    if (this.returnSSLResources()){
+      query.return_ssl_resources = this.returnSSLResources();
+    }
+    this.oauth.get(this.apiHost() + '/me' + url.format({ query: query }), accessToken, function (err, data) {
       if (err) return p.fail(err);
       var oauthUser = JSON.parse(data);
       p.fulfill(oauthUser);


### PR DESCRIPTION
In a https website all referenced urls (including images) must also be https to avoid mixed content warnings.
So when getting the Facebook '/me' object we should be able to tell Facebook that we want the returned resources to be prefixed with https rather than http.
See http://stackoverflow.com/questions/3199164/how-to-get-a-facebook-profile-picture-under-https
