### PR TITLE
Fix for 'this.redirect is missing' in openid

### DIFF
--- a/lib/modules/openid.js
+++ b/lib/modules/openid.js
@@ -45,6 +45,7 @@ everyModule.submodule('openid')
       .accepts('res')
       .promises(null)
   .sendToAuthenticationUri(function(req,res) {
+    var that = this;
 
     // Automatic hostname detection + assignment
     if (!this._myHostname || this._alwaysDetectHostname) {
@@ -53,7 +54,7 @@ everyModule.submodule('openid')
 
     this.relyingParty.authenticate(req.query[this.openidURLField()], false, function(err,authenticationUrl){
       if(err) return p.fail(err);
-      this.redirect(res, authenticationUrl);
+      that.redirect(res, authenticationUrl);
     });
   })
   .getSession( function(req) {


### PR DESCRIPTION
This is a fix for https://github.com/bnoguchi/everyauth/issues/255 .
