### PR TITLE
I'm a newbie to node.js so there's a good chance i'm missing something. ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ of helpers given previously, the alternative leveraging userAlias would look lik
 `everyauth` also provides convenience methods on the `ServerRequest` instance `req`. 
 From any scope that has access to `req`, you get the following convenience getters and methods:
 
-- `req.loggedIn` - a Boolean getter that tells you if the request is by a logged in user
+- `req.session.auth.loggedIn` - a Boolean getter that tells you if the request is by a logged in user
 - `req.user`     - the User document associated with the session
 - `req.logout()` - clears the sesion of your auth data
 


### PR DESCRIPTION
... but it seems like the loggedIn flag is not on the req object directly but on req.session.auth   Please verify this.  If you look at line 140 in index.js you'll see that it also uses req.session.auth
