### PR TITLE
Promise and this reference caused uncought exception in openid module sendToAuthenticationUri step

### DIFF
--- a/lib/modules/openid.js
+++ b/lib/modules/openid.js
@@ -50,11 +50,16 @@ everyModule.submodule('openid')
     if (!this._myHostname || this._alwaysDetectHostname) {
       this.myHostname(extractHostname(req));
     }
-
+    
+    var self = this
+    var p = this.Promise();
+    
     this.relyingParty.authenticate(req.query[this.openidURLField()], false, function(err,authenticationUrl){
       if(err) return p.fail(err);
-      this.redirect(res, authenticationUrl);
+      p.fulfill(authenticationUrl)
+      self.redirect(res, authenticationUrl);
     });
+    return p;
   })
   .getSession( function(req) {
     return req.session;


### PR DESCRIPTION
1) Openid module `sendToAuthenticationUri` step did not provide correct `Promise` object reference to use inside `this.relyingParty.authenticate` callback function. Also call back function did not fulfill promise(caused timeout error) and step itself did not return promise reference (caused uncaught exception). 

2) `this.redirect` in `this.relyingParty.authenticate` callback function thrown exception because `this` in the context did not have `redirect` method. Thus `self` was defined in outer context and `self.redirect` invoked.
