### PR TITLE
Update Github support to api v3

### DIFF
--- a/lib/modules/github.js
+++ b/lib/modules/github.js
@@ -27,24 +27,4 @@ oauthModule.submodule('github')
       p.fulfill(oauthUser);
     })
     return p;
-  })
-  .moduleErrback( function (err, seqValues) {
-    if (err instanceof Error) {
-      var next = seqValues.next;
-      return next(err);
-    } else if (err.extra) {
-      var ghResponse = err.extra.res
-        , serverResponse = seqValues.res;
-      serverResponse.writeHead(
-          ghResponse.statusCode
-        , ghResponse.headers);
-      serverResponse.end(err.extra.data);
-    } else if (err.statusCode) {
-      var serverResponse = seqValues.res;
-      serverResponse.writeHead(err.statusCode);
-      serverResponse.end(err.data);
-    } else {
-      console.error(err);
-      throw new Error('Unsupported error type');
-    }
   });


### PR DESCRIPTION
The Github API was upgrade to v3 verion recently, the old version github module will get a 404 response.
- changed apiHost
- changed user's info api
