### PR TITLE
Fix x-forwarded-proto check

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,7 +27,7 @@ function cloneArray (arr) {
 exports.extractHostname = function (req) {
   var headers = req.headers
     , protocol = (req.connection.server instanceof tls.Server ||
-                 (req.headers['x-forwarded-proto'] !== undefined && req.headers['x-forwarded-proto'].slice(0,5) == 'https'))
+                 (req.headers['x-forwarded-proto'] && req.headers['x-forwarded-proto'].slice(0,5) === 'https'))
                ? 'https://'
                : 'http://'
     , host = headers.host;


### PR DESCRIPTION
I had to make this small fix to get Everyauth to work with Express 3 in my app.
