### PR TITLE
`everyauth.debug` flag is deprecated, `debug` package is used now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2504,7 +2504,7 @@ Other introspection tools to describe (explanations coming soon):
 ### Debugging - Logging Module Steps
 
 To turn on debugging set `DEBUG=everyauth:*` environment variable.
-See [debug](https://npmjs.org/package/debug) package at npm
+See `debug` package at [npm](https://npmjs.org/package/debug) or [github](https://github.com/visionmedia/debug)
 
 ```
 $ DEBUG=everyauth:* node server.js

--- a/README.md
+++ b/README.md
@@ -2504,7 +2504,7 @@ Other introspection tools to describe (explanations coming soon):
 ### Debugging - Logging Module Steps
 
 To turn on debugging set `DEBUG=everyauth:*` environment variable.
-See [https://npmjs.org/package/debug](debug) package at npm
+See [debug](https://npmjs.org/package/debug) package at npm
 
 ```
 $ DEBUG=everyauth:* node server.js

--- a/README.md
+++ b/README.md
@@ -2503,38 +2503,39 @@ Other introspection tools to describe (explanations coming soon):
 
 ### Debugging - Logging Module Steps
 
-To turn on debugging:
+To turn on debugging set `DEBUG=everyauth:*` environment variable.
+See [https://npmjs.org/package/debug](debug) package at npm
 
-```javascript
-everyauth.debug = true;
+```
+$ DEBUG=everyauth:* node server.js
 ```
 
-Each everyauth auth strategy module is composed of steps. As each step begins and ends, everyauth will print out to the console the beginning and end of each step. So by turning on the debug flag, you get insight into what step everyauth is executing at any time.
+Each everyauth auth strategy module is composed of steps. As each step begins and ends, everyauth will print out to the console the beginning and end of each step. So by setting up `DEBUG=everyauth:*` environment variable, you get insight into what step everyauth is executing at any time.
 
 For example, here is some example debugging information output to the console
 during a Facebook Connect authorization:
 
 ```
-starting step - getAuthUri
-...finished step
-starting step - requestAuthUri
-...finished step
-starting step - getCode
-...finished step
-starting step - getAccessToken
-...finished step
-starting step - fetchOAuthUser
-...finished step
-starting step - getSession
-...finished step
-starting step - findOrCreateUser
-...finished step
-starting step - compile
-...finished step
-starting step - addToSession
-...finished step
-starting step - sendResponse
-...finished step
+  everyauth:step starting step - getAuthUri +XXms
+  everyauth:step ...finished step +XXms
+  everyauth:step starting step - requestAuthUri +XXms
+  everyauth:step ...finished step +XXms
+  everyauth:step starting step - getCode +XXms
+  everyauth:step ...finished step +XXms
+  everyauth:step starting step - getAccessToken +XXms
+  everyauth:step ...finished step +XXms
+  everyauth:step starting step - fetchOAuthUser +XXms
+  everyauth:step ...finished step +XXms
+  everyauth:step starting step - getSession +XXms
+  everyauth:step ...finished step +XXms
+  everyauth:step starting step - findOrCreateUser +XXms
+  everyauth:step ...finished step +XXms
+  everyauth:step starting step - compile +XXms
+  everyauth:step ...finished step +XXms
+  everyauth:step starting step - addToSession +XXms
+  everyauth:step ...finished step +XXms
+  everyauth:step starting step - sendResponse +XXms
+  everyauth:step ...finished step +XXms
 ```
 
 ### Debugging - Configuring Error Handling

--- a/example/server.js
+++ b/example/server.js
@@ -3,7 +3,7 @@ var express = require('express')
   , conf = require('./conf')
   , everyauthRoot = __dirname + '/..';
 
-everyauth.debug = true;
+// for debugging use DEBUG environment variable, see package debug at npm
 
 var usersById = {};
 var nextUserId = 0;

--- a/index.js
+++ b/index.js
@@ -9,7 +9,15 @@ everyauth.helpExpress = function () {
   return this;
 }
 
-everyauth.debug = false;
+
+everyauth.__defineGetter__('debug', function() {
+  console.warn('everyauth.debug is deprecated. Use DEBUG=everyauth:* environment variable and debug package at npm');
+  return debug.enabled;
+});
+everyauth.__defineSetter__('debug', function(value) {
+  console.warn('everyauth.debug is deprecated. Use DEBUG=everyauth:* environment variable (see debug package at npm)');
+});
+
 
 // The connect middleware. e.g.,
 //     connect(

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -1,3 +1,8 @@
+
+var debug = require('debug')('everyauth:promise');
+
+
+
 var Promise = function (values) {
   this._callbacks = [];
   this._errbacks = [];
@@ -85,8 +90,9 @@ ModulePromise.prototype.breakTo = function (seqName) {
   var args = Array.prototype.slice.call(arguments, 1);
   var _module = this.module
     , seq = _module._stepSequences[seqName];
-  if (_module.everyauth.debug)
-    console.log('breaking out to ' + seq.name);
+  
+  debug('breaking out to ' + seq.name);
+
   seq = seq.materialize();
   seq.start.apply(seq, args);
   // TODO Garbage collect the abandoned sequence

--- a/lib/step.js
+++ b/lib/step.js
@@ -1,4 +1,5 @@
-var Promise = require('./promise')
+var debug = require('debug')('everyauth:step')
+  , Promise = require('./promise')
   , clone = require('./utils').clone;
 
 var Step = module.exports = function Step (name, _module) {
@@ -31,10 +32,7 @@ Step.prototype = {
             }
           };
 
-
-      if (this.debug) {
-        console.log('starting step - ' + this.name);
-      }
+      debug('starting step - ' + this.name);
 
       var args = this._unwrapArgs(seq);
 
@@ -61,8 +59,7 @@ Step.prototype = {
       } catch (breakTo) {
         // Catch any sync breakTo's if any
         if (breakTo.isSeq) {
-          if (this.module.everyauth.debug)
-            console.log("breaking out to " + breakTo.name);
+          debug("breaking out to " + breakTo.name);
           breakTo.start.apply(breakTo, breakTo.initialArgs);
           // TODO Garbage collect the promise chain
           return;
@@ -92,9 +89,9 @@ Step.prototype = {
               : this.module.Promise(ret)
             : this.module.Promise([ret]);
 
-      if (seq.debug) {
+      if (debug.enabled) {
         ret.callback( function () {
-          console.log('...finished step');
+          debug('...finished step');
         });
       }
 
@@ -161,11 +158,5 @@ Step.prototype = {
 Object.defineProperty(Step.prototype, 'block', {
   get: function () {
     return this._block || (this._block = this.module[this.name]());
-  }
-});
-
-Object.defineProperty(Step.prototype, 'debug', {
-  get: function () {
-    return this.module.everyauth.debug;
   }
 });

--- a/lib/stepSequence.js
+++ b/lib/stepSequence.js
@@ -192,7 +192,3 @@ Object.defineProperty(StepSequence.prototype, 'steps', {
     return orderedSteps;
   }
 });
-
-Object.defineProperty(StepSequence.prototype, 'debug', {
-  get: function () { return this.module.everyauth.debug; }
-});

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "xml2js": ">=0.1.7",
     "node-swt": ">=0.1.1",
     "node-wsfederation": ">=0.1.1",
-    "debug": "0.5.0"
+    "debug": "~0.7.0"
   },
   "devDependencies": {
     "express": "3.x",

--- a/test/facebook.tobi.js
+++ b/test/facebook.tobi.js
@@ -11,7 +11,6 @@ describe('facebook', function () {
     delete require.cache[require.resolve('./app')]
     app = require('./app')
     var everyauth = require('../index');
-    everyauth.debug = false;
     tobi.Browser.browsers = {};
     browser = tobi.createBrowser(3000, 'local.host');
     browser.userAgent = 'Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.100 Safari/534.30';

--- a/test/mailchimp.tobi.js
+++ b/test/mailchimp.tobi.js
@@ -12,7 +12,6 @@ describe('Mailchimp', function () {
     app = require('./app')
     tobi.Browser.browsers = {};
     var everyauth = require('../index');
-    everyauth.debug = false;
     browser = tobi.createBrowser(3000, '127.0.0.1'); //mailchimp requires 127.0.0.1 instead of localhost in dev/test. 
     browser.userAgent = 'Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.100 Safari/534.30';
   });

--- a/test/password.tobi.js
+++ b/test/password.tobi.js
@@ -11,7 +11,6 @@ describe('password', function () {
     app = require('./app');
     tobi.Browser.browsers = {};
     var everyauth = require('../index');
-    everyauth.debug = false;
     browser = tobi.createBrowser(3000, 'local.host');
     browser.userAgent = 'Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.100 Safari/534.30';
   });

--- a/test/soundcloud.tobi.js
+++ b/test/soundcloud.tobi.js
@@ -12,7 +12,6 @@ describe('SoundCloud', function () {
     app = require('./app')
     tobi.Browser.browsers = {};
     var everyauth = require('../index');
-    everyauth.debug = false;
     browser = tobi.createBrowser(3000, 'local.host');
     browser.userAgent = 'Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.100 Safari/534.30';
   });

--- a/test/twitter.tobi.js
+++ b/test/twitter.tobi.js
@@ -12,7 +12,6 @@ describe('Twitter', function () {
     app = require('./app')
     tobi.Browser.browsers = {};
     var everyauth = require('../index');
-    everyauth.debug = false;
     browser = tobi.createBrowser(3000, 'local.host');
     browser.userAgent = 'Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.100 Safari/534.30';
   });


### PR DESCRIPTION
`everyauth.debug` flag is deprecated, `debug` package is used now.

See [README.md #debugging](https://github.com/langpavel/everyauth/blob/express3-debug/README.md#debugging)

**Note: express3 branch**
