### PR TITLE
fixed tumblr auth

### DIFF
--- a/lib/modules/tumblr.js
+++ b/lib/modules/tumblr.js
@@ -3,22 +3,24 @@ var oauthModule = require('./oauth')
 
 var twitter = module.exports =
 oauthModule.submodule('tumblr')
-  .apiHost('http://www.tumblr.com/api')
+  .apiHost('http://api.tumblr.com/v2')
   .oauthHost('http://www.tumblr.com')
   .entryPath('/auth/tumblr')
   .callbackPath('/auth/tumblr/callback')
   .sendCallbackWithAuthorize(false)
   .fetchOAuthUser( function (accessToken, accessTokenSecret, params) {
     var promise = this.Promise();
-    this.oauth.get(this.apiHost() + '/authenticate', accessToken, accessTokenSecret, function (err, data) {
+    this.oauth.get(this.apiHost() + '/user/info', accessToken, accessTokenSecret, function (err, data) {
       if (err) return promise.fail(err);
-      var parser = new Parser();
-      parser.on('end', function (result) {
-        var oauthUser = result.tumblelog['@'];
-        promise.fulfill(oauthUser);
-      });
-      parser.parseString(data);
+      
+      try {
+        data = JSON.parse(data);
+        promise.fulfill(data.response.user);
+      } catch (e) {
+        promise.fail(e);
+      }
     });
+
     return promise;
   })
   .convertErr( function (data) {


### PR DESCRIPTION
tumblr removed the authentication endpoint that was being used

http://developers.tumblr.com/post/28557510444/welcome-to-the-official-tumblr-developers-blog.

i updated it to the new method

http://www.tumblr.com/docs/en/api/v2#user-methods
