### PR TITLE
adding version to twitter api url

### DIFF
--- a/lib/modules/twitter.js
+++ b/lib/modules/twitter.js
@@ -10,7 +10,7 @@ oauthModule.submodule('twitter')
   .authorizePath('/oauth/authenticate')
   .fetchOAuthUser( function (accessToken, accessTokenSecret, params) {
     var promise = this.Promise();
-    this.oauth.get(this.apiHost() + '/users/show.json?user_id=' + params.user_id, accessToken, accessTokenSecret, function (err, data, res) {
+    this.oauth.get(this.apiHost() + '/1/users/show.json?user_id=' + params.user_id, accessToken, accessTokenSecret, function (err, data, res) {
       if (err) {
         err.extra = {data: data, res: res};
         return promise.fail(err);


### PR DESCRIPTION
Twitter recently removed all non-versioned api endpoints, as described here:

https://dev.twitter.com/discussions/10803

The change in the twitter API went live recently, and has been breaking our login with twitter.

This change prepends the required '/1' to the 'users/show.json' endpoint to get it functioning again
