### PR TITLE
Fixed twitter.js after Twitter dropped non-versioned API support

### DIFF
--- a/lib/modules/twitter.js
+++ b/lib/modules/twitter.js
@@ -10,7 +10,7 @@ oauthModule.submodule('twitter')
   .authorizePath('/oauth/authenticate')
   .fetchOAuthUser( function (accessToken, accessTokenSecret, params) {
     var promise = this.Promise();
-    this.oauth.get(this.apiHost() + '/users/show.json?user_id=' + params.user_id, accessToken, accessTokenSecret, function (err, data, res) {
+    this.oauth.get(this.apiHost() + '/1/users/show.json?user_id=' + params.user_id, accessToken, accessTokenSecret, function (err, data, res) {
       if (err) {
         err.extra = {data: data, res: res};
         return promise.fail(err);


### PR DESCRIPTION
Twitter recently started requiring you to specify which API version you're using when referencing certain Twitter API endpoints.  One of these endpoints was used in twitter.js which broke Twitter's Auth but was easily fixed by adding an API version to the request for user info from Twitter.
