### PR TITLE
Fixes "Step rememberTokenSecret...is promising" errors

### DIFF
--- a/lib/modules/oauth.js
+++ b/lib/modules/oauth.js
@@ -172,10 +172,16 @@ everyModule.submodule('oauth')
 
     promise = this.Promise();
     mod.verifier = verifier;
-    sess.save( function (err) {
-      if (err) return promise.fail(err);
-      promise.fulfill(requestToken, verifier);
-    });
+    try {
+        sess.save( function (err) {
+          if (err) return promise.fail(err);
+          promise.fulfill(requestToken, verifier);
+        });
+    }
+    catch (err) {
+        console.log(err);
+        promise.fulfill(requestToken, verifier);
+    }
     return promise;
   })
   .getSession( function(req) {
@@ -210,10 +216,16 @@ everyModule.submodule('oauth')
     mod.accessToken = auth.accessToken;
     mod.accessTokenSecret = auth.accessTokenSecret;
     // this._super() ?
-    sess.save( function (err) {
-      if (err) return promise.fail(err);
-      promise.fulfill();
-    });
+    try {
+        sess.save( function (err) {
+          if (err) return promise.fail(err);
+          promise.fulfill();
+        });
+    }
+    catch (err) {
+        console.log(err);
+        promise.fulfill();
+    }
     return promise;
   })
   .sendResponse( function (res, data) {

--- a/lib/step.js
+++ b/lib/step.js
@@ -68,7 +68,7 @@ Step.prototype = {
           return;
         } else {
           // Else, we have a regular exception
-          errorCallback(breakTo);
+          return errorCallback(breakTo);
         }
       }
 


### PR DESCRIPTION
Related to this issue which was preventing my use of the module,
[#75 - rememberTokenSecret of 'twitter' is promising: requestTokenSecret: however, the step returns nothing](https://github.com/bnoguchi/mongoose-auth/issues/75)
and [#164 - Error: Step rememberTokenSecret of `linkedin` is promising: requestTokenSecret](https://github.com/bnoguchi/everyauth/issues/164)

This pulls in 2 commits,
1. [daeq's c5a36bd7: one error is enough. stop after error callback](https://github.com/daeq/everyauth/commit/c5a36bd7855040df478f07f31c5a27cee84c7741) 
2. [alexahn's fdd06f: changes to fix twitter oauth module for express](https://github.com/alexahn/everyauth/commit/fdd06f2655285396dd6d328049b32ae4444b8c01)

which solved the problem for me. (Applied to my express3 branch, because I'm using express3, but they should also be applied to master.)

This bug seems to affect many users, so please escalate to high priority! Thank you!
