### PR TITLE
OpenID sendToAuthenticationUri lacks promise 

### DIFF
--- a/lib/modules/openid.js
+++ b/lib/modules/openid.js
@@ -46,6 +46,7 @@ everyModule.submodule('openid')
       .promises(null)
   .sendToAuthenticationUri(function(req,res) {
     var that = this;
+    var p = this.Promise();
 
     // Automatic hostname detection + assignment
     if (!this._myHostname || this._alwaysDetectHostname) {
@@ -56,6 +57,9 @@ everyModule.submodule('openid')
       if(err) return p.fail(err);
       that.redirect(res, authenticationUrl);
     });
+
+    p.fulfill();
+    return p;
   })
   .getSession( function(req) {
     return req.session;


### PR DESCRIPTION
 Openid module sendToAuthenticationUri step did not provide correct Promise object reference to use inside this.relyingParty.authenticate callback function. Also call back function did not fulfill promise(caused timeout error) and step itself did not return promise reference (caused uncaught exception).

original pull request https://github.com/bnoguchi/everyauth/pull/287 7 month old
