### PR TITLE
Fix for Issue 250: Dynamic scoping caching issue

### DIFF
--- a/lib/modules/oauth2.js
+++ b/lib/modules/oauth2.js
@@ -108,16 +108,17 @@ everyModule.submodule('oauth2')
         // function () {
         //   return this._scope && this.scope();
         // }
-        additionalParams[k] = // cache the function call
-          param = param.call(this);
-      }
-      if ('function' === typeof param) {
-        // this.scope() itself could be a function
-        // to allow for dynamic scope determination - e.g.,
-        // function (req, res) {
-        //   return req.session.onboardingPhase; // => "email"
-        // }
-        param = param.call(this, req, res);
+        param = param.call(this);
+        if ('function' === typeof param) {
+          // this.scope() itself could be a function
+          // to allow for dynamic scope determination - e.g.,
+          // function (req, res) {
+          //   return req.session.onboardingPhase; // => "email"
+          // }
+          param = param.call(this, req, res);
+        } else {
+          additionalParams[k] = param // cache the function call if not dynamically generated
+        }
       }
       params[k] = param;
     }


### PR DESCRIPTION
Dynamic scoping has been failing for oauth 2 modules. This fix disables caching for the configurations that are dynamic while preserving caching for static configurations.
