### PR TITLE
Fix to README docs - missing code section closing characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2425,6 +2425,7 @@ object whose parameter name keys map to description values:
 
 ```javascript
 everyauth.stripe.configurable();
+```
 
 ### Salesforce
 
@@ -2488,6 +2489,7 @@ object whose parameter name keys map to description values:
 
 ```javascript
 everyauth.salesforce.configurable();
+```
 
 ## Configuring a Module
 


### PR DESCRIPTION
In reference to #418 - merged request, but broke your readme docs - sorry!
