### PR TITLE
Password module: fixing respondToRegistrationSucceed method to receive correct parameters (missing req)

### DIFF
--- a/lib/modules/password.js
+++ b/lib/modules/password.js
@@ -325,7 +325,7 @@ everyModule.submodule('password')
     user = userOrErrors;
     return user;
   })
-  .respondToRegistrationSucceed( function (res, user) {
+  .respondToRegistrationSucceed( function (req, res, user) {
     this.redirect(res, this.registerSuccessRedirect());
   })
 


### PR DESCRIPTION
In the password module, the method respondToRegistrationSucceed, is suposed to receive the request in its signature, since this recent commit:
https://github.com/bnoguchi/everyauth/commit/2cf06a376a87f8cecbe43b556945efd186360fc7
This is making it fail, because the above commit only changed the step definition, but not the method itself. The commit in this pull request fixes this problem.
Tested and working properly on latest (0.4.1) version.
