### PR TITLE
Twitter API Version bump 

### DIFF
--- a/lib/modules/twitter.js
+++ b/lib/modules/twitter.js
@@ -10,7 +10,7 @@ oauthModule.submodule('twitter')
   .authorizePath('/oauth/authenticate')
   .fetchOAuthUser( function (accessToken, accessTokenSecret, params) {
     var promise = this.Promise();
-    this.oauth.get(this.apiHost() + '/1/users/show.json?user_id=' + params.user_id, accessToken, accessTokenSecret, function (err, data, res) {
+    this.oauth.get(this.apiHost() + '/1.1/users/show.json?user_id=' + params.user_id, accessToken, accessTokenSecret, function (err, data, res) {
       if (err) {
         err.extra = {data: data, res: res};
         return promise.fail(err);


### PR DESCRIPTION
As per https://dev.twitter.com/blog/api-blackout-testing-continues-may-22-2013
version 1 of the twitter API retired today. All calls are returning 410 status codes.

The Twitter module now looks to the new API (1.1) location after successfully logging in the user for their information.
