### PR TITLE
Update Twitter to API 1.1

### DIFF
--- a/lib/modules/twitter.js
+++ b/lib/modules/twitter.js
@@ -10,7 +10,7 @@ oauthModule.submodule('twitter')
   .authorizePath('/oauth/authenticate')
   .fetchOAuthUser( function (accessToken, accessTokenSecret, params) {
     var promise = this.Promise();
-    this.oauth.get(this.apiHost() + '/1/users/show.json?user_id=' + params.user_id, accessToken, accessTokenSecret, function (err, data, res) {
+    this.oauth.get(this.apiHost() + '/1.1/users/show.json?user_id=' + params.user_id, accessToken, accessTokenSecret, function (err, data, res) {
       if (err) {
         err.extra = {data: data, res: res};
         return promise.fail(err);


### PR DESCRIPTION
This trivial change fixes Twitter authentication, since the 1.0 API has been shut down.
