### PR TITLE
OpenID sendToAuthenticationUri lacks promise

### DIFF
--- a/lib/modules/openid.js
+++ b/lib/modules/openid.js
@@ -50,11 +50,16 @@ everyModule.submodule('openid')
     if (!this._myHostname || this._alwaysDetectHostname) {
       this.myHostname(extractHostname(req));
     }
+    
+    var p = this.Promise();
 
-    this.relyingParty.authenticate(req.query[this.openidURLField()], false, function(err,authenticationUrl){
+    this.relyingParty.authenticate(req.query[this.openidURLField()], false, (function(err,authenticationUrl){
       if(err) return p.fail(err);
       this.redirect(res, authenticationUrl);
-    });
+    }).bind(this));
+
+    p.fulfill();
+    return p;
   })
   .getSession( function(req) {
     return req.session;


### PR DESCRIPTION
Openid module sendToAuthenticationUri step did not provide correct Promise object reference to use inside this.relyingParty.authenticate callback function. Also call back function did not fulfill promise(caused timeout error) and step itself did not return promise reference (caused uncaught exception).

original pull request #379 which was merged and still this problem arises
