### PR TITLE
To handle error when the facebook app is in sandbox mode

### DIFF
--- a/lib/modules/oauth2.js
+++ b/lib/modules/oauth2.js
@@ -132,6 +132,7 @@ everyModule.submodule('oauth2')
     }
     if (!parsedUrl.query || !parsedUrl.query.code) {
       console.error("Missing code in querystring. The url looks like " + req.url);
+      return this.breakTo('authCallbackErrorSteps', req, res, next);
     }
     return parsedUrl.query && parsedUrl.query.code;
   })


### PR DESCRIPTION
To fix the following

<pre>
GET /auth/facebook/callback?error_code=901&error_message=This+app+is+in+sandbox+mode.++Edit+the+app+configuration+at+http%3A%2F%2Fdevelopers.facebook.com%2Fapps+to+make+the+app+publicly+visible. 500 28ms - 21b

        ^
Error: Can't render headers after they are sent to the client.
at ServerResponse.res._renderHeaders (/app/node_modules/express/node_modules/connect/lib/patch.js:69:27)
     at ServerResponse.writeHead (http.js:1065:20)
 http.js:721
     throw new Error('Can\'t render headers after they are sent to the client.'
     at ServerResponse.OutgoingMessage._renderHeaders (http.js:721:11)
     at ServerResponse.res.writeHead (/app/node_modules/express/node_modules/connect/lib/patch.js:75:22)
     at EveryModule._moduleErrback (/app/node_modules/everyauth/lib/modules/facebook.js:60:22)
     at errorCallback (/app/node_modules/everyauth/lib/step.js:29:15)
     at Promise.fail (/app/node_modules/everyauth/lib/promise.js:56:20)
     at Request.init.self.callback (/app/node_modules/everyauth/node_modules/request/main.js:120:22)
     at Request.module.exports.everyModule.submodule.definit.configurable.get.step.accepts.promises.step.accepts.promises.get.step.description.accepts.promises.canBreakTo.step.accepts.promises.step.accepts.promises.step.accepts.promises.step.accepts.promises.step.accepts.promises.step.accepts.promises.step.accepts.promises.stepseq.step.accepts.promises.getAuthUri.requestAuthUri.getCode.getAccessToken.compile.compiled.accessToken [as _callback] (/app/node_modules/everyauth/lib/modules/oauth2.js:189:57)
</pre>
