### PR TITLE
add version parameter to foursquare API request

### DIFF
--- a/lib/modules/foursquare.js
+++ b/lib/modules/foursquare.js
@@ -20,7 +20,7 @@ oauthModule.submodule('foursquare')
   .fetchOAuthUser( function (accessToken) {
     var promise = this.Promise()
       , userUrl = this.apiHost() + '/users/self'
-      , queryParams = { oauth_token: accessToken }
+      , queryParams = { oauth_token: accessToken, v: '20131201' }
     request.get({ url: userUrl, qs: queryParams}, function (err, res, body) {
       if (err) {
         err.extra = {res: res, data: body};


### PR DESCRIPTION
as of January 28, 2014 foursquare will drop support for API requests
without a version `v=YYYYMMDD` parameter

more: https://developer.foursquare.com/overview/versioning
