### PR TITLE
State variable not defined in some circumstances

### DIFF
--- a/lib/modules/oauth2.js
+++ b/lib/modules/oauth2.js
@@ -240,12 +240,13 @@ everyModule.submodule('oauth2')
   })
   .sendResponse( function (res, data) {
     var req = data.req;
-    var continueTo = req.query['state'];
-
-    if (continueTo) {
-      return this.redirect(res, continueTo);
+    if (typeof req.query !== 'undefined') {
+      var continueTo = req.query['state'];
+  
+      if (continueTo) {
+        return this.redirect(res, continueTo);
+      }
     }
-
     var redirectTo = this._redirectPath;
     if (!redirectTo)
       throw new Error('You must configure a redirectPath');


### PR DESCRIPTION
Instagram, for example, is complaining. This change correctly checks the `'state'` variable.
