### PR TITLE
Update facebook.js

### DIFF
--- a/lib/modules/facebook.js
+++ b/lib/modules/facebook.js
@@ -8,10 +8,10 @@ oauthModule.submodule('facebook')
       fields: 'specify returned fields: See http:/developers.facebook.com/docs/reference/api/user/'
   })
 
-  .apiHost('https://graph.facebook.com')
-  .oauthHost('https://graph.facebook.com')
+  .apiHost('https://graph.facebook.com/v2.0')
+  .oauthHost('https://graph.facebook.com/v2.0')
 
-  .authPath('https://www.facebook.com/dialog/oauth')
+  .authPath('https://www.facebook.com/v2.0/dialog/oauth')
 
   .entryPath('/auth/facebook')
   .callbackPath('/auth/facebook/callback')
@@ -73,7 +73,7 @@ oauthModule.submodule('facebook')
 
 fb.mobile = function (isMobile) {
   if (isMobile) {
-    this.authPath('https://m.facebook.com/dialog/oauth');
+    this.authPath('https://m.facebook.com/v2.0/dialog/oauth');
   }
   return this;
 };


### PR DESCRIPTION
FB API host is to be /v2.0, as it will be compulsory later on ('unversioned' v1.0 will be phased out)

info here: https://developers.facebook.com/docs/apps/upgrading
